### PR TITLE
Delete .ci.rosinstall to fix ign_ros2_controll installation in CI.

### DIFF
--- a/.ci.rosinstall
+++ b/.ci.rosinstall
@@ -1,4 +1,0 @@
-- git:
-    uri: https://github.com/ros-controls/gz_ros2_control.git
-    local-name: gz_ros2_control
-    version: master

--- a/.github/workflows/industrial_ci.yml
+++ b/.github/workflows/industrial_ci.yml
@@ -9,9 +9,6 @@ on:
     - '**.md'
   workflow_dispatch:
 
-env:
-  UPSTREAM_WORKSPACE: .ci.rosinstall
-
 jobs:
   industrial_ci:
     strategy:


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

ign_ros2_controllはaptでインストールできるので、.ci.rosinstallファイル経由でのインストールが不要になりました。
そのため、.ci.rosinstallファイルを削除します。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
いいえ

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
GitHub AciontsのCIが成功することを確認します。

また、https://github.com/rt-net/crane_x7_description/pull/8  がaptでインストールしたign_ros2_controlで動作することを確認済みです。

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
