### PR TITLE
joint_4の可動範囲調整

### DIFF
--- a/urdf/crane_x7.urdf.xacro
+++ b/urdf/crane_x7.urdf.xacro
@@ -96,7 +96,7 @@
   <xacro:property name="JOINT_3_LOWER_LIMIT" value="${radians(-157)}"/>
   <xacro:property name="JOINT_3_UPPER_LIMIT" value="${radians(157)}"/>
   <!-- JOINT_4はサーボ可動範囲を超えやすいため、LOWER_LIMITをサーボのリミット値より小さくする -->
-  <xacro:property name="JOINT_4_LOWER_LIMIT" value="${radians(-159)}"/>
+  <xacro:property name="JOINT_4_LOWER_LIMIT" value="${radians(-161)}"/>
   <!-- Gazeboの挙動がlimit付近で不安定なためUPPER_LIMITをサーボのリミット値より大きくする -->
   <!-- 参照: https://github.com/rt-net/crane_x7_ros/pull/162 -->
   <xacro:property name="JOINT_4_UPPER_LIMIT" value="${radians(0.001)}"/>


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
ロボットの姿勢によってはcheck_start_state_boundsでエラーが発生するため、URDF上の可動範囲を少し広げました。

```
[move_group-1] [ERROR] [1736413623.235048758] [move_group.moveit.moveit.ros.check_start_state_bounds]: Joint 'crane_x7_upper_arm_revolute_part_rotate_joint' from the starting state is outside bounds by: [-2.80412 ] should be in the range [-2.79253 ], [1.74533e-05 ].
[move_group-1] [ERROR] [1736413623.235087666] [move_group]: PlanningRequestAdapter 'CheckStartStateBounds' failed, because 'Start state out of bounds.'. Aborting planning pipeline.
```

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
しません

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->
joint_4を大きく曲げるカメラサンプルを動作しました。

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
    <!-- リポジトリのガイドラインがない場合は、rt-net organaizationのガイドラインが適用されます -->
    - If there is no guideline in the repository, [rt-net organization's guideline](https://github.com/rt-net/.github/blob/master/CONTRIBUTING.md) applies.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
